### PR TITLE
Convert numerical values to number type

### DIFF
--- a/parse.js
+++ b/parse.js
@@ -23,13 +23,17 @@ function Parse (argv) {
 		// Retrieve the argument name
 		argName = arg[0];
     
-    	// Remove "--" or "-"
+		// Remove "--" or "-"
 		if (argName.indexOf('-') === 0) {
 			argName = argName.slice(argName.slice(0, 2).lastIndexOf('-') + 1);
 		}
-
+		
 		// Associate defined value or initialize it to "true" state
-		argValue = (arg.length === 2) ? arg[1] : true;
+		argValue = (arg.length === 2)
+			? parseFloat(arg[1]).toString() === arg[1] // check if argument is valid number
+				? +arg[1]
+				: arg[1]
+			: true;
 
 		// Finally add the argument to the args set
 		args[argName] = argValue;


### PR DESCRIPTION
For example,

`index.js --a=1 b=2.12`

should give

```js
{
  "a": 1,
  "b": 2.12
}
```

instead of string types:

```js
{
  "a": "1",
  "b": "2.12"
}
```

Thanks!